### PR TITLE
Add Runner Tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,13 +155,6 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   ament_find_gmock()
-  #include_directories(${GMOCK_INLCUDE_DIRS})
-  #if(DEFINED GMOCK_LIBRARIES)
-  #  set(GMOCK_LIBRARY ${GMOCK_LIBRARIES})
-  #else()
-  #  set(GMOCK_LIBRARY gmock)
-  #endif()
-  set(GMOCK_LIBRARY gmock)
   add_library(
       test_utilities
       SHARED
@@ -176,7 +169,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_client_utils ros_sec_test_utilities)
 
   ament_add_gmock(test_runner test/ros_sec_test/runner/test_runner.cpp)
-  target_link_libraries(test_runner runner periodic_attack_component test_utilities ${GMOCK_LIBRARY})
+  target_link_libraries(test_runner runner periodic_attack_component test_utilities)
 
   ament_add_gtest(test_attack_noop test/ros_sec_test/attacks/noop/test_component.cpp)
   target_link_libraries(test_attack_noop noop_component ros_sec_test_utilities test_utilities)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(rcpputils REQUIRED)
 
 # Enable strict compiler flags if possible.
 include(CheckCXXCompilerFlag)
-set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-align -Wcast-qual -Wformat -Wwrite-strings -Wconversion -Wmissing-declarations)
+set(FLAGS -pedantic -Wno-long-long -Wall -Wextra -Wcast-align -Wcast-qual -Wformat -Wwrite-strings -Wconversion)
 foreach(FLAG ${FLAGS})
   check_cxx_compiler_flag(${FLAG} R${FLAG})
   if(${R${FLAG}})
@@ -108,9 +108,22 @@ target_link_libraries(
 )
 ament_target_dependencies(ros_sec_test_attacks "class_loader" "rclcpp" "rclcpp_lifecycle")
 
+# Define the runner node that manages executing attacks
+add_library(
+  runner
+  src/runner/runner.cpp
+)
+target_link_libraries(
+  runner
+  ros_sec_test_attacks
+  ros_sec_test_utilities
+)
+ament_target_dependencies(runner "rclcpp" "rclcpp_lifecycle")
+
 install(TARGETS
   ros_sec_test_attacks
   ros_sec_test_utilities
+  runner
   periodic_attack_component
   noop_component
   cpu_component
@@ -120,32 +133,41 @@ install(TARGETS
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
-# Define the runner node.
+# Define the main function
 add_executable(
-    runner
-    src/runner/main.cpp
-    src/runner/runner.cpp
+  ros_sec_test
+  src/runner/main.cpp
 )
 target_link_libraries(
-    runner
-    ros_sec_test_attacks
-    ros_sec_test_utilities
+  ros_sec_test
+  runner
 )
-ament_target_dependencies(runner "rclcpp" "rclcpp_lifecycle")
-install(TARGETS runner DESTINATION lib/${PROJECT_NAME})
+ament_target_dependencies(ros_sec_test "rclcpp")
+
+install(TARGETS ros_sec_test DESTINATION lib/${PROJECT_NAME})
 
 install(DIRECTORY examples DESTINATION share/${PROJECT_NAME})
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_cmake_gmock REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_find_gmock()
+  include_directories(${GMOCK_INLCUDE_DIRS})
+  if(DEFINED GMOCK_LIBRARIES)
+    set(GMOCK_LIBRARY ${GMOCK_LIBRARIES})
+  else()
+    set(GMOCK_LIBRARY gmock)
+  endif()
+
   add_library(
       test_utilities
       SHARED
       test/test_utilities/utility_fixtures.cpp
   )
   target_include_directories(test_utilities PUBLIC ${PROJECT_SOURCE_DIR}/test/include)
-  find_package(ament_cmake_gtest REQUIRED)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
 
   ament_add_gtest(test_service_utils test/ros_sec_test/utilities/test_service_utils.cpp)
   target_link_libraries(test_service_utils ros_sec_test_utilities)
@@ -153,8 +175,8 @@ if(BUILD_TESTING)
   ament_add_gtest(test_client_utils test/ros_sec_test/utilities/test_client_utils.cpp)
   target_link_libraries(test_client_utils ros_sec_test_utilities)
 
-  ament_add_gtest(test_runner test/ros_sec_test/runner/test_runner.cpp)
-  target_link_libraries(test_runner runner noop_component test_utilities)
+  ament_add_gmock(test_runner test/ros_sec_test/runner/test_runner.cpp)
+  target_link_libraries(test_runner runner periodic_attack_component test_utilities ${GMOCK_LIBRARY})
 
   ament_add_gtest(test_attack_noop test/ros_sec_test/attacks/noop/test_component.cpp)
   target_link_libraries(test_attack_noop noop_component ros_sec_test_utilities test_utilities)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,13 +155,13 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   ament_find_gmock()
-  include_directories(${GMOCK_INLCUDE_DIRS})
-  if(DEFINED GMOCK_LIBRARIES)
-    set(GMOCK_LIBRARY ${GMOCK_LIBRARIES})
-  else()
-    set(GMOCK_LIBRARY gmock)
-  endif()
-
+  #include_directories(${GMOCK_INLCUDE_DIRS})
+  #if(DEFINED GMOCK_LIBRARIES)
+  #  set(GMOCK_LIBRARY ${GMOCK_LIBRARIES})
+  #else()
+  #  set(GMOCK_LIBRARY gmock)
+  #endif()
+  set(GMOCK_LIBRARY gmock)
   add_library(
       test_utilities
       SHARED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,9 @@ if(BUILD_TESTING)
   ament_add_gtest(test_client_utils test/ros_sec_test/utilities/test_client_utils.cpp)
   target_link_libraries(test_client_utils ros_sec_test_utilities)
 
+  ament_add_gtest(test_runner test/ros_sec_test/runner/test_runner.cpp)
+  target_link_libraries(test_runner runner noop_component test_utilities)
+
   ament_add_gtest(test_attack_noop test/ros_sec_test/attacks/noop/test_component.cpp)
   target_link_libraries(test_attack_noop noop_component ros_sec_test_utilities test_utilities)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ROS2 SecTest
 
 **This code is experimental and uses features from ROS2 D**
+
 ROS2 has minimal security or limitations on node permissions by default. This package is meant
 to demonstrate ways a malicious or misconfigured node could harm the operations of a ROS2 system
 and demonstrate mitigations for those "attacks".
@@ -36,7 +37,7 @@ source install/local_setup.sh
 
 Run the noop demo
 ```bash
-ros2 run ros_sec_test runner __params:=`ros2 pkg prefix ros_sec_test`/share/ros_sec_test/examples/params.yaml
+ros2 run ros_sec_test ros_sec_test __params:=`ros2 pkg prefix ros_sec_test`/share/ros_sec_test/examples/params.yaml
 ```
 
 You should see something like the following output which demonstrates that

--- a/include/ros_sec_test/attacks/periodic_attack_component.hpp
+++ b/include/ros_sec_test/attacks/periodic_attack_component.hpp
@@ -36,23 +36,25 @@ namespace attacks
 class PeriodicAttackComponent : public rclcpp_lifecycle::LifecycleNode
 {
 public:
+  PeriodicAttackComponent();
   explicit PeriodicAttackComponent(std::string node_name);
   PeriodicAttackComponent(const PeriodicAttackComponent &) = delete;
   PeriodicAttackComponent & operator=(const PeriodicAttackComponent &) = delete;
+  virtual ~PeriodicAttackComponent() = default;
 
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_configure(const rclcpp_lifecycle::State & /* state */);
 
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_activate(const rclcpp_lifecycle::State & /* state */);
 
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_deactivate(const rclcpp_lifecycle::State & /* state */);
 
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_cleanup(const rclcpp_lifecycle::State & /* state */);
 
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_shutdown(const rclcpp_lifecycle::State & /* state */ state);
 
 protected:

--- a/include/ros_sec_test/attacks/periodic_attack_component.hpp
+++ b/include/ros_sec_test/attacks/periodic_attack_component.hpp
@@ -36,25 +36,24 @@ namespace attacks
 class PeriodicAttackComponent : public rclcpp_lifecycle::LifecycleNode
 {
 public:
-  PeriodicAttackComponent();
   explicit PeriodicAttackComponent(std::string node_name);
   PeriodicAttackComponent(const PeriodicAttackComponent &) = delete;
   PeriodicAttackComponent & operator=(const PeriodicAttackComponent &) = delete;
   virtual ~PeriodicAttackComponent() = default;
 
-  virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_configure(const rclcpp_lifecycle::State & /* state */);
 
-  virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_activate(const rclcpp_lifecycle::State & /* state */);
 
-  virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_deactivate(const rclcpp_lifecycle::State & /* state */);
 
-  virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_cleanup(const rclcpp_lifecycle::State & /* state */);
 
-  virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_shutdown(const rclcpp_lifecycle::State & /* state */ state);
 
 protected:

--- a/package.xml
+++ b/package.xml
@@ -23,8 +23,8 @@
   <exec_depend>rcutils</exec_depend>
   <exec_depend>ros2run</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
   <exec_depend>ros2run</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/src/attacks/periodic_attack_component.cpp
+++ b/src/attacks/periodic_attack_component.cpp
@@ -39,6 +39,9 @@ namespace ros_sec_test
 namespace attacks
 {
 
+PeriodicAttackComponent::PeriodicAttackComponent()
+: PeriodicAttackComponent("attack_node") {}
+
 PeriodicAttackComponent::PeriodicAttackComponent(std::string node_name)
 : rclcpp_lifecycle::LifecycleNode(
     node_name, "", rclcpp::NodeOptions().use_intra_process_comms(

--- a/src/attacks/periodic_attack_component.cpp
+++ b/src/attacks/periodic_attack_component.cpp
@@ -38,10 +38,6 @@ namespace ros_sec_test
 {
 namespace attacks
 {
-
-PeriodicAttackComponent::PeriodicAttackComponent()
-: PeriodicAttackComponent("attack_node") {}
-
 PeriodicAttackComponent::PeriodicAttackComponent(std::string node_name)
 : rclcpp_lifecycle::LifecycleNode(
     node_name, "", rclcpp::NodeOptions().use_intra_process_comms(

--- a/src/runner/runner.cpp
+++ b/src/runner/runner.cpp
@@ -21,8 +21,8 @@
 
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp/logger.hpp"
-#include "rclcpp_lifecycle/state.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/state.hpp"
 #include "ros_sec_test/attacks/factory_utils.hpp"
 
 using rclcpp::ParameterValue;

--- a/src/runner/runner.cpp
+++ b/src/runner/runner.cpp
@@ -22,6 +22,7 @@
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp/logger.hpp"
 #include "rclcpp_lifecycle/state.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "ros_sec_test/attacks/factory_utils.hpp"
 
 using rclcpp::ParameterValue;
@@ -54,6 +55,30 @@ Runner::Runner()
     warn_user_no_attack_nodes_passed();
   } else {
     initialize_attack_nodes(node_names);
+  }
+}
+
+Runner::Runner(const std::vector<rclcpp_lifecycle::LifecycleNode::SharedPtr> & attack_nodes)
+: node_(rclcpp::Node::make_shared("attacker_node", "",
+    rclcpp::NodeOptions().use_intra_process_comms(true))),
+  attack_nodes_(),
+  executor_(),
+  logger_(rclcpp::get_logger("Runner"))
+{
+  RCLCPP_INFO(logger_, "Initializing Runner");
+  executor_.add_node(node_);
+  if (attack_nodes.empty()) {
+    warn_user_no_attack_nodes_passed();
+  } else {
+    for (const auto & attack_node : attack_nodes) {
+      AttackNodeData node_data = {
+        attack_node,
+        std::make_shared<LifecycleServiceClient>(node_.get(), attack_node->get_name())
+      };
+      attack_nodes_.emplace_back(std::move(node_data));
+      executor_.add_node(attack_node->get_node_base_interface());
+      RCLCPP_INFO(logger_, "Adding attack node '%s'", attack_node->get_name());
+    }
   }
 }
 

--- a/src/runner/runner.hpp
+++ b/src/runner/runner.hpp
@@ -51,7 +51,6 @@ public:
    * CAVEAT: rclcpp::init() *must* be called before instantiating this object.
    */
   Runner();
-
   /// Use a vector of already instantiated nodes.
   /**
    * CAVEAT: rclcpp::init() *must* be called before instantiating this object.

--- a/src/runner/runner.hpp
+++ b/src/runner/runner.hpp
@@ -46,11 +46,17 @@ namespace runner
 class Runner
 {
 public:
-  /// Instantiate all nodes without activating them.
+  /// Instantiate all nodes from parameter without activating them.
   /**
    * CAVEAT: rclcpp::init() *must* be called before instantiating this object.
    */
   Runner();
+
+  /// Use a vector of already instantiated nodes.
+  /**
+   * CAVEAT: rclcpp::init() *must* be called before instantiating this object.
+   */
+  explicit Runner(const std::vector<rclcpp_lifecycle::LifecycleNode::SharedPtr> & attack_nodes);
 
   Runner(const Runner &) = delete;
   Runner & operator=(const Runner &) = delete;

--- a/src/utilities/lifecycle_service_client.cpp
+++ b/src/utilities/lifecycle_service_client.cpp
@@ -86,7 +86,7 @@ bool LifecycleServiceClient::configure()
 bool LifecycleServiceClient::shutdown()
 {
   return change_state(rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::
-           TRANSITION_DEACTIVATE));
+           TRANSITION_ACTIVE_SHUTDOWN));
 }
 
 }  // namespace utilities

--- a/test/include/test_utilities/periodic_attack_component_mock.hpp
+++ b/test/include/test_utilities/periodic_attack_component_mock.hpp
@@ -1,0 +1,41 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef TEST_UTILITIES__PERIODIC_ATTACK_COMPONENT_MOCK_HPP_
+#define TEST_UTILITIES__PERIODIC_ATTACK_COMPONENT_MOCK_HPP_
+#include <string>
+
+#include "gmock/gmock.h"
+
+#include "ros_sec_test/attacks/periodic_attack_component.hpp"
+
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+#include "rclcpp_lifecycle/state.hpp"
+
+
+using PeriodicAttackComponent = ros_sec_test::attacks::PeriodicAttackComponent;
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+class MockPeriodicAttackComponent : public PeriodicAttackComponent
+{
+public:
+  explicit MockPeriodicAttackComponent(std::string node_name)
+  : PeriodicAttackComponent(node_name) {}
+  MOCK_METHOD1(on_configure, CallbackReturn(const rclcpp_lifecycle::State &));
+  MOCK_METHOD1(on_activate, CallbackReturn(const rclcpp_lifecycle::State &));
+  MOCK_METHOD1(on_deactivate, CallbackReturn(const rclcpp_lifecycle::State &));
+  MOCK_METHOD1(on_cleanup, CallbackReturn(const rclcpp_lifecycle::State &));
+  MOCK_METHOD1(on_shutdown, CallbackReturn(const rclcpp_lifecycle::State &));
+};
+
+#endif  // TEST_UTILITIES__PERIODIC_ATTACK_COMPONENT_MOCK_HPP_

--- a/test/ros_sec_test/runner/test_runner.cpp
+++ b/test/ros_sec_test/runner/test_runner.cpp
@@ -1,0 +1,23 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <gtest/gtest.h>
+
+#include "ros_sec_test/runner/runner.hpp"
+#include "test_utilities/utility_fixtures.hpp"
+
+using ros_sec_test::test::test_utilities::ROSTestingFixture;
+
+
+TEST_F(ROSTestingFixture, test_nothing) {
+};


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-robotics/ROS2-SecTest/issues/3
*Description of changes:*
- Adds tests for runner class
- Creates a mock class for PeriodicAttackComponent 
```
Test project /home/ubuntu/sec_test_ws/build/ros_sec_test
      Start  1: test_service_utils
 1/13 Test  #1: test_service_utils ...............   Passed    0.40 sec
      Start  2: test_client_utils
 2/13 Test  #2: test_client_utils ................   Passed    0.62 sec
      Start  3: test_runner
 3/13 Test  #3: test_runner ......................   Passed    0.62 sec
      Start  4: test_attack_noop
 4/13 Test  #4: test_attack_noop .................   Passed    1.23 sec
      Start  5: test_attack_resources_cpu
 5/13 Test  #5: test_attack_resources_cpu ........   Passed    1.23 sec
      Start  6: test_attack_resources_disk
 6/13 Test  #6: test_attack_resources_disk .......   Passed    1.23 sec
      Start  7: test_attack_resources_memory
 7/13 Test  #7: test_attack_resources_memory .....   Passed    1.23 sec
      Start  8: copyright
 8/13 Test  #8: copyright ........................   Passed    0.96 sec
      Start  9: cppcheck
 9/13 Test  #9: cppcheck .........................   Passed    0.97 sec
      Start 10: cpplint
10/13 Test #10: cpplint ..........................   Passed    1.54 sec
      Start 11: lint_cmake
11/13 Test #11: lint_cmake .......................   Passed    0.91 sec
      Start 12: uncrustify
12/13 Test #12: uncrustify .......................   Passed    1.18 sec
      Start 13: xmllint
13/13 Test #13: xmllint ..........................   Passed    1.19 sec

100% tests passed, 0 tests failed out of 13

Label Time Summary:
copyright     =   0.96 sec*proc (1 test)
cppcheck      =   0.97 sec*proc (1 test)
cpplint       =   1.54 sec*proc (1 test)
gmock         =   0.62 sec*proc (1 test)
gtest         =   5.94 sec*proc (6 tests)
lint_cmake    =   0.91 sec*proc (1 test)
linter        =   6.76 sec*proc (6 tests)
uncrustify    =   1.18 sec*proc (1 test)
xmllint       =   1.19 sec*proc (1 test)

Total Test time (real) =  13.32 sec
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
