### PR TITLE
Update shutdown state transition

### DIFF
--- a/src/utilities/lifecycle_service_client.cpp
+++ b/src/utilities/lifecycle_service_client.cpp
@@ -86,7 +86,7 @@ bool LifecycleServiceClient::configure()
 bool LifecycleServiceClient::shutdown()
 {
   return change_state(rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::
-           TRANSITION_DEACTIVATE));
+           TRANSITION_ACTIVE_SHUTDOWN));
 }
 
 }  // namespace utilities


### PR DESCRIPTION
Signed-off-by: Ryan Newell <ryanewel@amazon.com>

*Issue #, if available:*

*Description of changes:*

In lifecycle_service_client, the shutdown method doesn't actually shutdown the node. This change just makes the action consistent with the name.

Tests
```
Running tests...
Test project /home/ubuntu/sec_test_ws/build/ros_sec_test
      Start  1: test_service_utils
 1/12 Test  #1: test_service_utils ...............   Passed    0.38 sec
      Start  2: test_client_utils
 2/12 Test  #2: test_client_utils ................   Passed    0.62 sec
      Start  3: test_attack_noop
 3/12 Test  #3: test_attack_noop .................   Passed    1.26 sec
      Start  4: test_attack_resources_cpu
 4/12 Test  #4: test_attack_resources_cpu ........   Passed    1.24 sec
      Start  5: test_attack_resources_disk
 5/12 Test  #5: test_attack_resources_disk .......   Passed    1.25 sec
      Start  6: test_attack_resources_memory
 6/12 Test  #6: test_attack_resources_memory .....   Passed    1.26 sec
      Start  7: copyright
 7/12 Test  #7: copyright ........................   Passed    0.98 sec
      Start  8: cppcheck
 8/12 Test  #8: cppcheck .........................   Passed    1.02 sec
      Start  9: cpplint
 9/12 Test  #9: cpplint ..........................   Passed    1.53 sec
      Start 10: lint_cmake
10/12 Test #10: lint_cmake .......................   Passed    0.94 sec
      Start 11: uncrustify
11/12 Test #11: uncrustify .......................   Passed    1.18 sec
      Start 12: xmllint
12/12 Test #12: xmllint ..........................   Passed    1.27 sec

100% tests passed, 0 tests failed out of 12

Label Time Summary:
copyright     =   0.98 sec*proc (1 test)
cppcheck      =   1.02 sec*proc (1 test)
cpplint       =   1.53 sec*proc (1 test)
gtest         =   6.03 sec*proc (6 tests)
lint_cmake    =   0.94 sec*proc (1 test)
linter        =   6.92 sec*proc (6 tests)
uncrustify    =   1.18 sec*proc (1 test)
xmllint       =   1.27 sec*proc (1 test)

Total Test time (real) =  12.95 sec
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
