### PR TITLE
Add attack duration parameter

### DIFF
--- a/examples/params.yaml
+++ b/examples/params.yaml
@@ -2,3 +2,4 @@ attacker_node:
   ros__parameters:
     attack_nodes:
         - 'noop'
+    attack_duration: 1

--- a/src/runner/runner.hpp
+++ b/src/runner/runner.hpp
@@ -91,6 +91,12 @@ private:
    */
   std::vector<std::string> retrieve_attack_nodes_names();
 
+  /// Read the attack duration in seconds from the node parameter.
+  /**
+   * \return Duration of attack.
+   */
+  std::chrono::seconds retrieve_attack_duration_s();
+
   /// Relies on lifecycle client to start and stop all attacks.
   void start_and_stop_all_nodes();
 

--- a/src/runner/runner.hpp
+++ b/src/runner/runner.hpp
@@ -93,7 +93,7 @@ private:
 
   /// Read the attack duration in seconds from the node parameter.
   /**
-   * \return Duration of attack.
+   * \return Duration of attack in seconds.
    */
   std::chrono::seconds retrieve_attack_duration_s();
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds an attack duration parameter that specifies how long to run the attacks for.

```
Test project /home/ubuntu/sec_test_ws/build/ros_sec_test
      Start  1: test_service_utils
 1/13 Test  #1: test_service_utils ...............   Passed    0.37 sec
      Start  2: test_client_utils
 2/13 Test  #2: test_client_utils ................   Passed    0.62 sec
      Start  3: test_runner
 3/13 Test  #3: test_runner ......................   Passed    0.63 sec
      Start  4: test_attack_noop
 4/13 Test  #4: test_attack_noop .................   Passed    1.22 sec
      Start  5: test_attack_resources_cpu
 5/13 Test  #5: test_attack_resources_cpu ........   Passed    1.23 sec
      Start  6: test_attack_resources_disk
 6/13 Test  #6: test_attack_resources_disk .......   Passed    1.22 sec
      Start  7: test_attack_resources_memory
 7/13 Test  #7: test_attack_resources_memory .....   Passed    1.23 sec
      Start  8: copyright
 8/13 Test  #8: copyright ........................   Passed    0.98 sec
      Start  9: cppcheck
 9/13 Test  #9: cppcheck .........................   Passed    0.99 sec
      Start 10: cpplint
10/13 Test #10: cpplint ..........................   Passed    1.58 sec
      Start 11: lint_cmake
11/13 Test #11: lint_cmake .......................   Passed    0.94 sec
      Start 12: uncrustify
12/13 Test #12: uncrustify .......................   Passed    1.20 sec
      Start 13: xmllint
13/13 Test #13: xmllint ..........................   Passed    0.97 sec

100% tests passed, 0 tests failed out of 13

Label Time Summary:
copyright     =   0.98 sec*proc (1 test)
cppcheck      =   0.99 sec*proc (1 test)
cpplint       =   1.58 sec*proc (1 test)
gmock         =   0.63 sec*proc (1 test)
gtest         =   5.89 sec*proc (6 tests)
lint_cmake    =   0.94 sec*proc (1 test)
linter        =   6.66 sec*proc (6 tests)
uncrustify    =   1.20 sec*proc (1 test)
xmllint       =   0.97 sec*proc (1 test)

Total Test time (real) =  13.18 sec
```
Manually tested the attack duration feature:
Specifying a value of 10s -> attacks are run for 10s
Specifying a value of <0s -> attack are run indefinitely 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
