### PR TITLE
Fix bug where mode is not specified in open.

### DIFF
--- a/src/attacks/resources/disk/component.cpp
+++ b/src/attacks/resources/disk/component.cpp
@@ -53,7 +53,7 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 Component::on_activate(const rclcpp_lifecycle::State & /* state */)
 {
   RCLCPP_INFO(get_logger(), "on_activate() is called.");
-  fd_ = open("attack.dat", O_WRONLY | O_CREAT);
+  fd_ = open("attack.dat", O_WRONLY | O_CREAT, 0600);
   return CallbackReturn::SUCCESS;
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed open to be called with mode 0600. Calls to "open" with O_CREAT require the mode parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
